### PR TITLE
feat: 학과 공지사항은 제목, 작성 일자, 링크를 가지고 있다.

### DIFF
--- a/app/models/department_notice.py
+++ b/app/models/department_notice.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+class DepartmentNotice:
+    def __init__(self, title: str, created_date: datetime, link: str):
+        self.__title = title
+        self.__created_date = created_date
+        self.__link = link
+
+    @property
+    def title(self) -> str:
+        return self.__title
+
+    @property
+    def created_date(self) -> datetime:
+        return self.__created_date
+
+    @property
+    def link(self) -> str:
+        return self.__link
+
+    def __repr__(self) -> str:
+        return (f"DepartmentNotice(title={self.__title!r}, "
+                f"created_date={self.__created_date!r}, link={self.__link!r})")

--- a/tests/models/test_department_notice.py
+++ b/tests/models/test_department_notice.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+from datetime import datetime
+from app.models.department_notice import DepartmentNotice
+
+class TestDepartmentNotice(TestCase):
+    def test_department_notice_repr(self):
+        # Given
+        title = "2025학년도 1학기 학석사연계과정 학생 선발 안내"
+        created_date = datetime(2024, 10, 29)
+        link = "https://computer.chungbuk.ac.kr/bbs/bbs.php?task=view&db=notice&no=2381&page=1&search=&searchKey=&category=&pgID=ID12415888101"
+
+        # When
+        notice = DepartmentNotice(
+            title=title,
+            created_date=created_date,
+            link=link
+        )
+
+        # Then
+        expected_repr = (f"DepartmentNotice(title={title!r}, "
+                        f"created_date={created_date!r}, link={link!r})")
+        self.assertEqual(repr(notice), expected_repr)


### PR DESCRIPTION
## 📄 Summary

#72 